### PR TITLE
Fix transaction fuzzer

### DIFF
--- a/app/src/crypto.c
+++ b/app/src/crypto.c
@@ -192,6 +192,7 @@ zxerr_t crypto_sign(uint8_t *signature,
 #else
 
 #include "blake2.h"
+#include "hexutils.h"
 
 zxerr_t blake2b_hash(const unsigned char *in, unsigned int inLen,
                      unsigned char *out){
@@ -201,6 +202,13 @@ zxerr_t blake2b_hash(const unsigned char *in, unsigned int inLen,
     } else {
         return zxerr_ok;
     }
+}
+
+zxerr_t crypto_extractPublicKey(const uint32_t path[HDPATH_LEN_DEFAULT], uint8_t *pubKey, uint16_t pubKeyLen) {
+    const char *tmp = "7f747b67bd3fe63c2a736739dfe40156d622347346e70f68f51c178a75ce5537a087c03779";
+    parseHexString(pubKey, pubKeyLen, tmp);
+
+    return zxerr_ok;
 }
 
 #endif

--- a/tests/ui_tests.cpp
+++ b/tests/ui_tests.cpp
@@ -24,13 +24,6 @@
 #include "parser.h"
 #include "common.h"
 
-zxerr_t crypto_extractPublicKey(const uint32_t path[HDPATH_LEN_DEFAULT], uint8_t *pubKey, uint16_t pubKeyLen) {
-    const char *tmp = "7f747b67bd3fe63c2a736739dfe40156d622347346e70f68f51c178a75ce5537a087c03779";
-    parseHexString(pubKey, pubKeyLen, tmp);
-
-    return zxerr_ok;
-}
-
 zxerr_t pubkey_to_hash(const uint8_t *pubkey, uint16_t pubkeyLen, uint8_t *out){
     const char *tmp = "24749ecb377e548d114538c2d5504d77645257e21b2b8ee430170c74ab3ddc6d";
     parseHexString(out, 32, tmp);


### PR DESCRIPTION
Running fuzzers is unfortunately not documented.

You can build transaction fuzzer with:

```shell
git submodule update --init --recursive
cmake . -Bbuild -DCMAKE_BUILD_TYPE=Debug -DENABLE_FUZZING=1 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang
make -C build fuzz-parser_parse
```

Then, run the fuzzer with:

```shell
./fuzzing/run-fuzzers.py
```